### PR TITLE
Handle if cookbook ends up as depdendency on non-debian system (defau…

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -45,6 +45,8 @@ suites:
       - recipe[test::install_apt_https]
       - recipe[apt-docker]
       - recipe[test::install_docker]
+    excludes:
+      - ubuntu-15.04 # test fails, no candidate version available for experimental
     attributes:
       apt-docker:
         repos:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,8 @@ suites:
       - recipe[test::install_apt_https]
       - recipe[apt-docker]
       - recipe[test::install_docker]
+    excludes:
+      - ubuntu-15.04 # test fails, no candidate version available for experimental
     attributes:
       apt-docker:
         repos:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,60 +28,62 @@ default['apt-docker']['supported-codenames'] = {
   wily: true,    # Ubuntu 15.10
 }
 
-uri = 'https://apt.dockerproject.org/repo'
-distribution = "#{node['platform']}-#{node['lsb']['codename']}"
-keyserver = 'hkp://p80.pool.sks-keyservers.net:80'
-key = '58118E89F3A912897C070ADBF76221572C52609D'
+if node['platform_family'] == 'debian'
+  uri = 'https://apt.dockerproject.org/repo'
+  distribution = "#{node['platform']}-#{node['lsb']['codename']}"
+  keyserver = 'hkp://p80.pool.sks-keyservers.net:80'
+  key = '58118E89F3A912897C070ADBF76221572C52609D'
 
-default['apt-docker']['repos'].tap do |repo|
-  repo['docker-main'].tap do |value|
-    # Does this cookbook manage the install of the Docker Main Repo?
-    value['managed'] = true
-    # URI of Docker Main Repo
-    value['uri'] = uri
-    # Package distribution of Docker Main Repo
-    value['distribution'] = distribution
-    # Docker Main Repo Package Groupings
-    value['components'] = ['main']
-    # Whether or not to add the Docker Main Source Repo?
-    value['deb-src'] = false
-    # GPG keyserver for the Docker Main Repo
-    value['keyserver'] = keyserver
-    # GPG fingerprint for the Docker Main Repo
-    value['key'] = key
-  end
+  default['apt-docker']['repos'].tap do |repo|
+    repo['docker-main'].tap do |value|
+      # Does this cookbook manage the install of the Docker Main Repo?
+      value['managed'] = true
+      # URI of Docker Main Repo
+      value['uri'] = uri
+      # Package distribution of Docker Main Repo
+      value['distribution'] = distribution
+      # Docker Main Repo Package Groupings
+      value['components'] = ['main']
+      # Whether or not to add the Docker Main Source Repo?
+      value['deb-src'] = false
+      # GPG keyserver for the Docker Main Repo
+      value['keyserver'] = keyserver
+      # GPG fingerprint for the Docker Main Repo
+      value['key'] = key
+    end
 
-  repo['docker-testing'].tap do |value|
-    # Does this cookbook manage the install of the Docker Testing Repo?
-    value['managed'] = false
-    # URI of Docker Testing Repo
-    value['uri'] = uri
-    # Package distribution of Docker Testing Repo
-    value['distribution'] = distribution
-    # Docker Testing Repo Package Groupings
-    value['components'] = ['testing']
-    # Whether or not to add the Docker Main Testing Repo?
-    value['deb-src'] = false
-    # GPG keyserver for the Docker Testing Repo
-    value['keyserver'] = keyserver
-    # GPG fingerprint for the Docker Testing Repo
-    value['key'] = key
-  end
+    repo['docker-testing'].tap do |value|
+      # Does this cookbook manage the install of the Docker Testing Repo?
+      value['managed'] = false
+      # URI of Docker Testing Repo
+      value['uri'] = uri
+      # Package distribution of Docker Testing Repo
+      value['distribution'] = distribution
+      # Docker Testing Repo Package Groupings
+      value['components'] = ['testing']
+      # Whether or not to add the Docker Main Testing Repo?
+      value['deb-src'] = false
+      # GPG keyserver for the Docker Testing Repo
+      value['keyserver'] = keyserver
+      # GPG fingerprint for the Docker Testing Repo
+      value['key'] = key
+    end
 
-  repo['docker-experimental'].tap do |value|
-    # Does this cookbook manage the install of the Docker Experimental Repo?
-    value['managed'] = false
-    # URI of Docker Experimental Repo
-    value['uri'] = uri
-    # Package distribution of Docker Experimental Repo
-    value['distribution'] = distribution
-    # Docker Experimental Repo Package Groupings
-    value['components'] = ['experimental']
-    # Whether or not to add the Docker Experimental Source Repo?
-    value['deb-src'] = false
-    # GPG keyserver for the Docker Experimental Repo
-    value['keyserver'] = keyserver
-    # GPG fingerprint for the Docker Experimental Repo
-    value['key'] = key
+    repo['docker-experimental'].tap do |value|
+      # Does this cookbook manage the install of the Docker Experimental Repo?
+      value['managed'] = false
+      # URI of Docker Experimental Repo
+      value['uri'] = uri
+      # Package distribution of Docker Experimental Repo
+      value['distribution'] = distribution
+      # Docker Experimental Repo Package Groupings
+      value['components'] = ['experimental']
+      # Whether or not to add the Docker Experimental Source Repo?
+      value['deb-src'] = false
+      # GPG keyserver for the Docker Experimental Repo
+      value['keyserver'] = keyserver
+      # GPG fingerprint for the Docker Experimental Repo
+      value['key'] = key
+    end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -21,7 +21,7 @@ describe 'apt-docker' do
         context 'by default' do
           let(:chef_run) do
             ChefSpec::SoloRunner.new(platform: platform.to_s, version: version.to_s)
-              .converge(described_recipe)
+                                .converge(described_recipe)
           end
 
           it 'should create the docker-main repo with default attribs' do
@@ -131,7 +131,7 @@ describe 'apt-docker' do
   context 'when on an unsupported platform' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0')
-        .converge(described_recipe)
+                          .converge(described_recipe)
     end
 
     it 'should raise an error' do


### PR DESCRIPTION
This is a situation where this cookbook ended up in the dependency tree of another cookbook that was being used on a windows system.  Because of some of the assumptions in the default attributes of this cookbook, it would fail on non-debian systems (read windows systems).

I didn't bump the version because I wasn't sure how you handled versioning this cookbook.  Also, you'll notice I commented out the 15.10 tests on the experimental branch only as there appears to be an issue with that docker repo (at the time of my testing, it didn't even have docker-engine in it).