### PR TITLE
Enable support for 16.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ platforms:
   - name: ubuntu-14.04
   # - name: ubuntu-14.10 # apt sources yield 404's
   - name: ubuntu-15.04
+  - name: ubuntu-16.04
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ test builds (ie. release candidates).  Experimental is for experimental builds.
       utopic: true,  # Ubuntu 14.10
       vivid: true,   # Ubuntu 15.04
       wily: true,    # Ubuntu 15.10
+      xenial: true,  # Ubuntu 16.04
     }
     ```
 - Docker Main Repo

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['apt-docker']['supported-codenames'] = {
   utopic: true,  # Ubuntu 14.10
   vivid: true,   # Ubuntu 15.04
   wily: true,    # Ubuntu 15.10
+  xenial: true,  # Ubuntu 16.04
 }
 
 uri = 'https://apt.dockerproject.org/repo'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'st.isidore.de.seville@gmail.com'
 license 'MIT'
 description 'Installs/Configures apt Docker Vendor-Specific Repository'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.3.1'
 
 source_url 'https://github.com/st-isidore-de-seville/cookbook-apt-docker'
 issues_url 'https://github.com/st-isidore-de-seville/cookbook-apt-docker/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,7 @@ platform_family = node['platform_family']
 platform = node['platform']
 platform_version = node['platform_version']
 
-fail("#{platform_family}/#{platform}/#{platform_version} is not supported by the default recipe") \
+raise("#{platform_family}/#{platform}/#{platform_version} is not supported by the default recipe") \
  unless platform_family?('debian') &&
         node['apt-docker']['supported-codenames']
         .select { |_version, is_included| is_included }

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -22,7 +22,7 @@ describe 'apt-docker' do
         context 'by default' do
           let(:chef_run) do
             ChefSpec::SoloRunner.new(platform: platform.to_s, version: version.to_s)
-              .converge(described_recipe)
+                                .converge(described_recipe)
           end
 
           it 'should create the docker-main repo with default attribs' do
@@ -132,7 +132,7 @@ describe 'apt-docker' do
   context 'when on an unsupported platform' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'redhat', version: '7.0')
-        .converge(described_recipe)
+                          .converge(described_recipe)
     end
 
     it 'should raise an error' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -10,7 +10,8 @@ platform_test_matrix = {
     '14.04' => 'trusty',
     '14.10' => 'utopic',
     '15.04' => 'vivid',
-    '15.10' => 'wily'
+    '15.10' => 'wily',
+    '16.04' => 'xenial'
   }
 }
 


### PR DESCRIPTION
(Duplicate of #5)

Test that is green on my machine:
- rspec
- rubocop
- kitchen `default-ubuntu-1604`.
- kitchen `test-ubuntu-1604`
